### PR TITLE
Add SOL-BTC bridging stub

### DIFF
--- a/bridging_module.py
+++ b/bridging_module.py
@@ -1,0 +1,49 @@
+"""
+bridge_module.py
+Automated SOL/SPL to BTC (SegWit) bridge logic for GhostSniperOmega
+This is a scaffold for integrating with Wormhole/Allbridge/Jupiter bridges.
+Destination: any valid SegWit (bc1...) address (e.g., BlueWallet/BlueCoin)
+"""
+import asyncio
+
+# --- CONFIG ---
+BRIDGE_PROVIDER = "wormhole"  # or "allbridge", "jupiter" (stub)
+# User's BlueWallet/BlueCoin SegWit address (BC_W)
+BC_W = "bc1q2syyf4ctx8w44ypqy0873440cazjrhy9xxhw85"
+BTC_DEST = "bc1q2syyf4ctx8w44ypqy0873440cazjrhy9xxhw85"  # User's BlueWallet/BlueCoin SegWit address
+
+# --- MAIN LOGIC ---
+async def bridge_sol_to_btc(sol_amount, btc_address, ghost_client=None):
+    """
+    Automates bridging SOL/SPL from Solana to BTC SegWit address via a cross-chain bridge.
+    Args:
+        sol_amount (float): Amount of SOL to bridge
+        btc_address (str): SegWit destination (must start with 'bc1')
+        ghost_client: Optional Solana RPC client or wallet context
+    Returns:
+        dict: Bridge transaction result or error
+    """
+    if not btc_address.startswith("bc1"):
+        return {"error": "Invalid SegWit address (must start with 'bc1')"}
+    # --- Pseudocode for bridge interaction ---
+    # Replace this stub with actual bridge contract call or API integration
+    try:
+        # Example: Wormhole bridge interaction (pseudo)
+        print(f"[GHOST] Initiating bridge: {sol_amount} SOL → {btc_address}")
+        # tx = wormhole_bridge.send_solana_to_btc(sol_amount, btc_address, ghost_client)
+        # await tx.confirm()
+        # Simulate bridge
+        await asyncio.sleep(2)
+        print(f"[GHOST] Bridge complete: {sol_amount} SOL sent to {btc_address}")
+        return {"status": "success", "amount": sol_amount, "to": btc_address}
+    except Exception as e:
+        print(f"[GHOST] Bridge error: {e}")
+        return {"error": str(e)}
+
+# Example usage (for async context):
+# await bridge_sol_to_btc(0.1, BC_W)
+
+if __name__ == "__main__":
+    import asyncio
+    # Example: bridge 0.05 SOL to BC_W address
+    asyncio.run(bridge_sol_to_btc(0.05, BC_W))


### PR DESCRIPTION
## Summary
- add a `bridging_module.py` script that demonstrates bridging SOL to a BTC SegWit address

## Testing
- `python bridging_module.py`

------
https://chatgpt.com/codex/tasks/task_e_68493cc844808327af11257e9317a1df