### PR TITLE
Add Terminal API module

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Echo-sound
 
-This repository contains experiments with automated cryptocurrency trading bots. The latest module, **AI Sniper X**, demonstrates a proof-of-concept Solana sniper that uses locally hosted LLMs for autonomous trading decisions.
+This repository contains experiments with automated cryptocurrency trading bots and related infrastructure.
 
-See [`ai-sniper-x/README.md`](ai-sniper-x/README.md) for details.
+The **AI Sniper X** module demonstrates a proof-of-concept Solana sniper that uses locally hosted LLMs for autonomous trading decisions. See [`ai-sniper-x/README.md`](ai-sniper-x/README.md) for details.
+
+The **Terminal API** module provides an HTTP service for executing terminal commands. See [`terminal-api/README.md`](terminal-api/README.md) for setup and deployment instructions.

--- a/terminal-api/Dockerfile
+++ b/terminal-api/Dockerfile
@@ -1,0 +1,32 @@
+# Use official Python image
+FROM python:3.11-slim
+
+# Prevent Python from writing .pyc files
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONUNBUFFERED=1
+
+# Install system dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    libssl-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# Set workdir
+WORKDIR /app
+
+# Install Python dependencies
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy application code
+COPY . .
+
+# Expose port
+EXPOSE 3000
+
+# Default environment variables
+ENV API_KEY=default_key
+ENV PORT=3000
+
+# Run the application
+CMD ["python", "app.py"]

--- a/terminal-api/README.md
+++ b/terminal-api/README.md
@@ -1,0 +1,31 @@
+# Terminal API
+
+This module provides a small HTTP service for executing terminal commands. It is intended for controlled environments where remote command execution is required.
+
+## Features
+- REST API defined in `terminal_api.yaml`.
+- Flask-based backend (`app.py`).
+- Containerized with `Dockerfile`.
+- Terraform scripts for AWS Fargate deployment.
+- Load testing with Locust (`locustfile.py`).
+- Example GPT prompts for integrating with language models.
+
+## Quick Start
+1. Install dependencies:
+   ```sh
+   pip install -r requirements.txt
+   ```
+2. Run the server:
+   ```sh
+   API_KEY=mykey python app.py
+   ```
+3. Execute a command:
+   ```sh
+   curl -X POST http://localhost:3000/execute \
+     -H "X-API-Key: mykey" \
+     -H "Content-Type: application/json" \
+     -d '{"command": "ls"}'
+   ```
+
+## Deployment
+See `terraform/` for AWS deployment via ECS and `Dockerfile` for containerization instructions.

--- a/terminal-api/app.py
+++ b/terminal-api/app.py
@@ -1,0 +1,104 @@
+from flask import Flask, request, jsonify
+import subprocess
+import os
+import time
+import logging
+from functools import wraps
+
+app = Flask(__name__)
+
+# Configure logging
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+# API keys (in production, use secrets manager)
+API_KEYS = {
+    os.environ.get("API_KEY", "default_key"): True
+}
+
+def require_api_key(f):
+    @wraps(f)
+    def decorated_function(*args, **kwargs):
+        api_key = request.headers.get('X-API-Key')
+        if api_key not in API_KEYS:
+            logger.warning(f"Unauthorized access attempt with key: {api_key}")
+            return jsonify({"error": "Unauthorized"}), 401
+        return f(*args, **kwargs)
+    return decorated_function
+
+@app.route('/health', methods=['GET'])
+def health_check():
+    return jsonify({"status": "healthy", "version": "1.0.0"})
+
+@app.route('/execute', methods=['POST'])
+@require_api_key
+def execute_command():
+    data = request.get_json()
+
+    # Validate input
+    if not data or 'command' not in data:
+        return jsonify({"error": "Missing command parameter"}), 400
+
+    command = data['command']
+    working_dir = data.get('working_dir', os.getcwd())
+    timeout = data.get('timeout', 30)
+
+    # Basic security check
+    if any(banned in command for banned in ['rm ', 'format ', 'dd ', 'shutdown', 'reboot']):
+        return jsonify({"error": "Potentially dangerous command blocked"}), 403
+
+    # Validate timeout
+    if not (1 <= timeout <= 300):
+        return jsonify({"error": "Timeout must be between 1 and 300 seconds"}), 400
+
+    # Resolve home directory
+    if working_dir.startswith('~'):
+        working_dir = os.path.expanduser(working_dir)
+
+    # Check directory exists
+    if not os.path.isdir(working_dir):
+        return jsonify({"error": f"Directory not found: {working_dir}"}), 400
+
+    logger.info(f"Executing command: {command} in {working_dir}")
+
+    try:
+        start_time = time.time()
+
+        # Execute command
+        process = subprocess.Popen(
+            command,
+            cwd=working_dir,
+            shell=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True
+        )
+
+        try:
+            stdout, stderr = process.communicate(timeout=timeout)
+            exit_code = process.returncode
+        except subprocess.TimeoutExpired:
+            process.kill()
+            stdout, stderr = process.communicate()
+            exit_code = -1
+            stderr = f"Command timed out after {timeout} seconds\n{stderr}"
+
+        exec_time = time.time() - start_time
+
+        response = {
+            "command": command,
+            "output": stdout,
+            "error": stderr,
+            "exit_code": exit_code,
+            "execution_time": round(exec_time, 3)
+        }
+
+        logger.info(f"Command executed in {exec_time:.3f}s with exit code {exit_code}")
+        return jsonify(response)
+
+    except Exception as e:
+        logger.error(f"Command execution failed: {str(e)}")
+        return jsonify({"error": str(e)}), 500
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=int(os.environ.get('PORT', 3000)))

--- a/terminal-api/gpt_prompts.md
+++ b/terminal-api/gpt_prompts.md
@@ -1,0 +1,40 @@
+# Terminal Commander GPT Instructions
+
+Use these prompts to interact with the Terminal Commander API via a GPT-powered assistant.
+
+## Available Function
+- `executeCommand` – executes a terminal command on the server.
+
+## Guidelines
+1. Confirm with the user before executing commands.
+2. Explain what the command will do in plain language.
+3. Avoid destructive commands unless explicitly requested.
+4. Always include a reasonable `timeout` (recommended: 30 seconds).
+5. Use `working_dir` to set the command context when needed.
+
+## Examples
+
+### List files in the home directory
+```json
+{
+  "command": "ls -la",
+  "working_dir": "~"
+}
+```
+
+### Check disk usage
+```json
+{
+  "command": "df -h",
+  "working_dir": "/"
+}
+```
+
+### Find Python files containing `requests`
+```json
+{
+  "command": "grep -rl 'import requests' . --include='*.py'",
+  "working_dir": "~/projects/myapp",
+  "timeout": 60
+}
+```

--- a/terminal-api/locustfile.py
+++ b/terminal-api/locustfile.py
@@ -1,0 +1,30 @@
+from locust import HttpUser, task, between
+import random
+
+commands = [
+    "ls -la",
+    "docker ps -a",
+    "git status",
+    "df -h",
+    "free -m",
+    "ps aux | grep python"
+]
+
+class TerminalUser(HttpUser):
+    wait_time = between(1, 3)
+
+    @task
+    def execute_command(self):
+        command = random.choice(commands)
+        self.client.post(
+            "/execute",
+            json={
+                "command": command,
+                "timeout": 10
+            },
+            headers={"X-API-Key": "test_key"}
+        )
+
+    @task(3)
+    def health_check(self):
+        self.client.get("/health")

--- a/terminal-api/requirements.txt
+++ b/terminal-api/requirements.txt
@@ -1,0 +1,2 @@
+flask
+gunicorn

--- a/terminal-api/terminal_api.yaml
+++ b/terminal-api/terminal_api.yaml
@@ -1,0 +1,79 @@
+openapi: 3.1.0
+info:
+  title: Terminal Commander API
+  description: Production-ready terminal command execution service
+  version: 1.0.0
+  contact:
+    name: Support
+    url: https://support.example.com
+servers:
+  - url: https://terminal-api.example.com
+    description: Production API
+  - url: http://localhost:3000
+    description: Local development
+paths:
+  /execute:
+    post:
+      summary: Execute terminal command
+      description: Runs a terminal command and returns the results
+      operationId: executeCommand
+      requestBody:
+        description: Command to execute
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                command:
+                  type: string
+                  description: Terminal command to execute
+                  example: ls -la
+                working_dir:
+                  type: string
+                  description: Working directory for command
+                  default: /
+                  example: ~/projects
+                timeout:
+                  type: integer
+                  description: Execution timeout in seconds
+                  default: 30
+                  minimum: 1
+                  maximum: 300
+              required:
+                - command
+      responses:
+        '200':
+          description: Command executed successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  output:
+                    type: string
+                    description: Command output (stdout)
+                  error:
+                    type: string
+                    description: Error output (stderr)
+                  exit_code:
+                    type: integer
+                    description: Command exit status
+                  execution_time:
+                    type: number
+                    description: Execution time in seconds
+        '400':
+          description: Invalid request
+        '500':
+          description: Command execution error
+security:
+  - api_key: []
+components:
+  securitySchemes:
+    api_key:
+      type: apiKey
+      name: X-API-Key
+      in: header
+      description: Simple API key authentication
+security:
+  - api_key: []

--- a/terminal-api/terraform/main.tf
+++ b/terminal-api/terraform/main.tf
@@ -1,0 +1,157 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.region
+}
+
+resource "aws_ecr_repository" "terminal_api" {
+  name = "terminal-api"
+}
+
+resource "aws_ecs_cluster" "terminal_cluster" {
+  name = "terminal-cluster"
+}
+
+resource "aws_ecs_task_definition" "terminal_task" {
+  family                   = "terminal-task"
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+  cpu                      = "256"
+  memory                   = "512"
+  execution_role_arn       = aws_iam_role.ecs_task_execution_role.arn
+
+  container_definitions = jsonencode([
+    {
+      name      = "terminal-api"
+      image     = "${aws_ecr_repository.terminal_api.repository_url}:latest"
+      cpu       = 256
+      memory    = 512
+      essential = true
+      portMappings = [{
+        containerPort = 3000
+        hostPort      = 3000
+      }]
+      environment = [
+        {
+          name  = "API_KEY"
+          value = var.api_key
+        }
+      ]
+    }
+  ])
+}
+
+resource "aws_lb" "terminal_lb" {
+  name               = "terminal-lb"
+  internal           = false
+  load_balancer_type = "application"
+  security_groups    = [aws_security_group.allow_http.id]
+  subnets            = [aws_subnet.public.id]
+}
+
+resource "aws_lb_target_group" "terminal_tg" {
+  name        = "terminal-tg"
+  port        = 3000
+  protocol    = "HTTP"
+  target_type = "ip"
+  vpc_id      = aws_vpc.main.id
+
+  health_check {
+    path     = "/health"
+    interval = 30
+  }
+}
+
+resource "aws_lb_listener" "terminal_listener" {
+  load_balancer_arn = aws_lb.terminal_lb.arn
+  port              = "80"
+  protocol          = "HTTP"
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.terminal_tg.arn
+  }
+}
+
+resource "aws_ecs_service" "terminal_service" {
+  name            = "terminal-service"
+  cluster         = aws_ecs_cluster.terminal_cluster.id
+  task_definition = aws_ecs_task_definition.terminal_task.arn
+  desired_count   = 2
+  launch_type     = "FARGATE"
+
+  network_configuration {
+    subnets          = [aws_subnet.public.id]
+    security_groups  = [aws_security_group.allow_http.id]
+    assign_public_ip = true
+  }
+
+  load_balancer {
+    target_group_arn = aws_lb_target_group.terminal_tg.arn
+    container_name   = "terminal-api"
+    container_port   = 3000
+  }
+}
+
+resource "aws_iam_role" "ecs_task_execution_role" {
+  name = "ecs_task_execution_role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = "ecs-tasks.amazonaws.com"
+        }
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "ecs_task_execution_role_policy" {
+  role       = aws_iam_role.ecs_task_execution_role.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+}
+
+resource "aws_vpc" "main" {
+  cidr_block = "10.0.0.0/16"
+}
+
+resource "aws_subnet" "public" {
+  vpc_id            = aws_vpc.main.id
+  cidr_block        = "10.0.1.0/24"
+  availability_zone = "us-east-1a"
+}
+
+resource "aws_security_group" "allow_http" {
+  name        = "allow_http"
+  description = "Allow HTTP traffic"
+  vpc_id      = aws_vpc.main.id
+
+  ingress {
+    from_port   = 3000
+    to_port     = 3000
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+output "load_balancer_url" {
+  value = "http://${aws_lb.terminal_lb.dns_name}"
+}

--- a/terminal-api/terraform/variables.tf
+++ b/terminal-api/terraform/variables.tf
@@ -1,0 +1,10 @@
+variable "api_key" {
+  description = "API key for terminal access"
+  type        = string
+  sensitive   = true
+}
+
+variable "region" {
+  description = "AWS region"
+  default     = "us-east-1"
+}


### PR DESCRIPTION
## Summary
- add REST API service for remote command execution
- document API usage and GPT prompts
- containerize with Dockerfile
- add Terraform deployment and load test config
- update repo README with module info

## Testing
- `python -m py_compile terminal-api/app.py`


------
https://chatgpt.com/codex/tasks/task_e_68575978f55c8327a4ea687387129982