### PR TITLE
Add GitHub workflow for bot with secret

### DIFF
--- a/.github/workflows/gpt-action.yml
+++ b/.github/workflows/gpt-action.yml
@@ -1,0 +1,23 @@
+name: Run AI Sniper X
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 * * * *'
+
+jobs:
+  run-sniper:
+    runs-on: ubuntu-latest
+    env:
+      ANT_API_KEY: ${{ secrets.ANT_API_KEY }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - name: Install dependencies
+        run: |
+          pip install -r ai-sniper-x/requirements.txt
+      - name: Execute bot
+        run: python ai-sniper-x/main.py

--- a/README.md
+++ b/README.md
@@ -3,3 +3,10 @@
 This repository contains experiments with automated cryptocurrency trading bots. The latest module, **AI Sniper X**, demonstrates a proof-of-concept Solana sniper that uses locally hosted LLMs for autonomous trading decisions.
 
 See [`ai-sniper-x/README.md`](ai-sniper-x/README.md) for details.
+
+## GitHub Actions
+
+The repository includes a workflow that can run the sniper bot on a schedule.
+To enable it, add a repository secret named `ANT_API_KEY` containing your API
+token (for example the string starting with `sk-ant-api03`). The workflow file is
+located at `.github/workflows/gpt-action.yml`.

--- a/ai-sniper-x/README.md
+++ b/ai-sniper-x/README.md
@@ -24,4 +24,9 @@ An experimental crypto trading bot with locally hosted LLM decision engine. This
    python main.py
    ```
 
+### GitHub Actions
+
+You can also run the bot via GitHub Actions. Create a repository secret
+`ANT_API_KEY` with your API token and trigger the **Run AI Sniper X** workflow.
+
 LLM models must be downloaded locally. This script will attempt to use `llama-cpp-python` first and fall back to `gpt4all` if available.


### PR DESCRIPTION
## Summary
- add scheduled GitHub Actions workflow to run the sniper bot
- document how to configure the `ANT_API_KEY` secret

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685c630941248327971fb12821698a98